### PR TITLE
fix: 修复缺少环境变量时 next build 崩溃

### DIFF
--- a/app/api/admin/courses/parse/route.ts
+++ b/app/api/admin/courses/parse/route.ts
@@ -3,11 +3,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { GoogleGenAI } from '@google/genai'
 import { logger } from '@/lib/logger'
 
-// 初始化 Gemini AI（使用环境变量验证）
+// 初始化 Gemini AI（环境变量验证延迟到请求处理时，见下方 handler 内的 !apiKey 检查）
+// ⚠️ 不在模块顶层 throw，避免 next build 阶段因缺少运行时密钥而中断构建
 const apiKey = process.env.GEMINI_API_KEY
-if (!apiKey) {
-  throw new Error('GEMINI_API_KEY 未配置，请在 .env 文件中添加')
-}
 
 // 智能识别课程类型的提示词 - 使用简单的键值对格式
 const IDENTIFY_COURSE_TYPE_PROMPT = `你是一个专业的课程分析专家。请分析以下课程文档，识别其课程类型并提取基本信息。

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -4,19 +4,21 @@ import { createClient } from '@supabase/supabase-js'
 // Service Role Client - 绕过RLS，拥有完整权限
 // ⚠️ 仅在服务器端API使用，绝不要在客户端使用！
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-if (!supabaseUrl) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable')
-}
-
-if (!supabaseServiceKey) {
-  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable')
-}
-
 // 创建具有Service Role权限的客户端
+// ⚠️ 环境变量检查延迟到调用时（而非模块加载时），避免 next build 阶段因缺少
+//    运行时密钥而中断（collect page data 会加载此模块）
 export const createServiceClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable')
+  }
+
+  if (!supabaseServiceKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable')
+  }
+
   return createClient(supabaseUrl, supabaseServiceKey, {
     auth: {
       autoRefreshToken: false,


### PR DESCRIPTION
## 问题
Vercel 部署（master 的 Preview 构建）失败：`Failed to collect page data for /api/admin/courses/parse`，根因是 `Missing NEXT_PUBLIC_SUPABASE_URL` 与 `GEMINI_API_KEY 未配置`。这些模块在**顶层**检查运行时密钥并 `throw`，`next build` 加载模块时即崩溃。

## 修复
- `lib/supabase/service.ts`：env 检查移入 `createServiceClient()`（调用时才检查）
- `app/api/admin/courses/parse/route.ts`：移除顶层 throw，handler 内已有 `!apiKey` 守卫

安全性不变（运行时仍验证密钥）；仅避免构建阶段崩溃。

## 验证
- 本地隐藏 `.env` 复现 Vercel 失败 → 应用修复后原密钥错误消失
- 满配密钥正常 `npm run build` 通过（exit 0），无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)