### PR TITLE
fix: 进一步消除 next build 缺环境变量崩溃（lib/supabase.ts + 测试页）

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -8,16 +8,13 @@ import type { Database } from '@/types/database'
 export type { Database }
 export type { Json } from '@/types/database'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+// ⚠️ 构建时（next build 的 collect page data 会加载本模块）允许密钥缺失，
+//    用占位符兜底避免顶层 throw / createClient 报错导致构建失败；
+//    运行时的真实校验由各客户端调用及 getAdminClient() 负责。
+//    （与 lib/supabase/client.ts 的占位符策略保持一致）
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co'
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key'
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-
-if (!supabaseUrl) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set')
-}
-if (!supabaseAnonKey) {
-  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not set')
-}
 
 // 基础客户端
 export const supabase = createServiceClient<Database>(supabaseUrl, supabaseAnonKey)

--- a/pages/test-summarize.tsx
+++ b/pages/test-summarize.tsx
@@ -1004,3 +1004,9 @@ export default function TestSummarizePage() {
     </div>
   )
 }
+
+// 强制按需渲染（SSR），避免构建期预渲染此测试页时
+// createClientComponentClient() 因缺少环境变量而中断构建
+export async function getServerSideProps() {
+  return { props: {} }
+}


### PR DESCRIPTION
延续 #17，修复 Preview 构建剩余两处崩溃：

- `lib/supabase.ts`：顶层改用占位符兜底，不再因缺 `NEXT_PUBLIC_SUPABASE_URL/ANON_KEY` 抛错（与 `lib/supabase/client.ts` 既有策略一致）
- `pages/test-summarize.tsx`：加 `getServerSideProps` 强制 SSR，避免构建期预渲染该测试页崩溃

## 验证
本地隐藏 `.env` 模拟 Preview：密钥/预渲染致命错误全部消失（0 行），仅剩本地无法联网下载 Google 字体的网络问题（Vercel 不受影响）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)