### PR TITLE
fix: 赛斯365 网页下载壁纸转为标准 JPEG 格式

### DIFF
--- a/components/seth365/BatchDownloadModal.tsx
+++ b/components/seth365/BatchDownloadModal.tsx
@@ -5,14 +5,14 @@ import { motion } from 'framer-motion'
 import { X, Download, Calendar, ChevronLeft, ChevronRight, Check, Loader2, Info, Lock } from 'lucide-react'
 import {
   getWallpapersForDate,
-  getWallpaperUrl,
   getFileName,
   isDateUnlocked,
   LAUNCH_DATE,
   formatDate,
   getDaysInMonth,
   Language,
-  Orientation
+  Orientation,
+  downloadWallpaperAsJpeg
 } from '@/lib/seth365/wallpaper'
 
 interface BatchDownloadModalProps {
@@ -191,15 +191,9 @@ export function BatchDownloadModal({ onClose }: BatchDownloadModalProps) {
         if (filterLanguage !== 'all' && wallpaper.language !== filterLanguage) continue
         if (filterOrientation !== 'all' && wallpaper.orientation !== filterOrientation) continue
 
-        const url = getWallpaperUrl(wallpaper)
-        const fileName = getFileName(wallpaper)
-
-        const link = document.createElement('a')
-        link.href = url
-        link.download = fileName
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
+        // 文件名（不含扩展名，转换函数会补上 .jpg）
+        const baseFileName = getFileName(wallpaper).replace(/\.webp$/i, '')
+        await downloadWallpaperAsJpeg(wallpaper, baseFileName)
 
         downloaded++
         setDownloadProgress(Math.round((downloaded / wallpaperCount) * 100))

--- a/components/seth365/WallpaperCarousel.tsx
+++ b/components/seth365/WallpaperCarousel.tsx
@@ -21,7 +21,8 @@ import {
   filterWallpapers,
   Language,
   Orientation,
-  formatDate
+  formatDate,
+  downloadWallpaperAsJpeg
 } from '@/lib/seth365/wallpaper'
 
 interface WallpaperCarouselProps {
@@ -91,13 +92,8 @@ export function WallpaperCarousel({ date, onOpenPosterEditor, onOpenBatchDownloa
   }
 
   const handleDownload = async (wallpaper: Wallpaper) => {
-    const url = getWallpaperUrl(wallpaper)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `赛斯365_${formatDate(wallpaper.date)}_${getDisplayName(wallpaper)}.webp`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    const baseFileName = `赛斯365_${formatDate(wallpaper.date)}_${getDisplayName(wallpaper)}`
+    await downloadWallpaperAsJpeg(wallpaper, baseFileName)
   }
 
   const handleDownloadAll = async () => {

--- a/lib/seth365/wallpaper.ts
+++ b/lib/seth365/wallpaper.ts
@@ -125,3 +125,66 @@ export function getDaysInMonth(year: number, month: number): Date[] {
 export function formatDate(date: Date): string {
   return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`
 }
+
+// 加载图片为 HTMLImageElement
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new window.Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error(`图片加载失败: ${src}`))
+    img.src = src
+  })
+}
+
+// 触发浏览器下载一个 Blob
+function triggerBlobDownload(blob: Blob, fileName: string): void {
+  const objectUrl = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = objectUrl
+  link.download = fileName
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  // 释放对象 URL（延迟以确保下载已开始）
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 1000)
+}
+
+// 下载壁纸为标准 JPEG 格式
+// 部分浏览器/系统对 .webp 兼容性不佳，统一转换为 JPEG 后下载，
+// 同时使用 Blob URL 确保自定义文件名生效
+export async function downloadWallpaperAsJpeg(
+  wallpaper: Wallpaper,
+  baseFileName: string
+): Promise<void> {
+  const url = getWallpaperUrl(wallpaper)
+  const jpegFileName = `${baseFileName}.jpg`
+
+  try {
+    const img = await loadImage(url)
+    const canvas = document.createElement('canvas')
+    canvas.width = img.naturalWidth
+    canvas.height = img.naturalHeight
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('无法创建画布上下文')
+
+    // JPEG 不支持透明通道，先填充白色背景
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.drawImage(img, 0, 0)
+
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, 'image/jpeg', 0.95)
+    )
+    if (!blob) throw new Error('图片转换失败')
+
+    triggerBlobDownload(blob, jpegFileName)
+  } catch {
+    // 回退：直接下载原始 webp 文件
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${baseFileName}.webp`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+}


### PR DESCRIPTION
## 问题
网页端下载当前/批量下载直接下载原始 **webp** 文件，部分 Windows 系统/软件不识别（用户反馈图片格式不对），且 `download` 自定义文件名失效，显示原始名如 `26.6.28.ES2.webp`。App 端无此问题。

## 修复
新增 `downloadWallpaperAsJpeg()`（`lib/seth365/wallpaper.ts`）：用 canvas 将 webp 转为 **JPEG（质量 0.95，白底）**，经 Blob URL 下载。
- 通用 JPEG，任何系统直接打开
- Blob URL 保证自定义文件名生效
- 内置回退：转换失败时退回直接下载原始 webp

接入 `WallpaperCarousel.tsx`（下载当前）与 `BatchDownloadModal.tsx`（批量下载）。壁纸为同源资源，canvas 不会被污染。本地 `npm run build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)